### PR TITLE
Addition of 6th and 7th thermistor tables

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -19,6 +19,8 @@
 // 3 is mendel-parts thermistor
 // 4 is 10k thermistor
 // 5 is ParCan supplied 104GT-2 100K
+// 6 is EPCOS 100k
+// 7 is 100k Honeywell thermistor 135-104LAG-J01
 #define THERMISTORHEATER 3
 #define THERMISTORBED 1
 

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -225,6 +225,109 @@ const short temptable_5[NUMTEMPS_5][2] = {
 };
 #endif
 
+#if (THERMISTORHEATER == 6) || (THERMISTORBED == 6) // 100k Epcos thermistor
+#define NUMTEMPS_6 36
+const short temptable_6[NUMTEMPS_6][2] = {
+   {28, 250},
+   {31, 245},
+   {35, 240},
+   {39, 235},
+   {42, 230},
+   {44, 225},
+   {49, 220},
+   {53, 215},
+   {62, 210},
+   {73, 205},
+   {72, 200},
+   {94, 190},
+   {102, 185},
+   {116, 170},
+   {143, 160},
+   {183, 150},
+   {223, 140},
+   {270, 130},
+   {318, 120},
+   {383, 110},
+   {413, 105},
+   {439, 100},
+   {484, 95},
+   {513, 90},
+   {607, 80},
+   {664, 70},
+   {781, 60},
+   {810, 55},
+   {849, 50},
+   {914, 45},
+   {914, 40},
+   {935, 35},
+   {954, 30},
+   {970, 25},
+   {978, 22},
+   {1008, 3}
+};
+#endif
+
+#if (THERMISTORHEATER == 7) || (THERMISTORBED == 7) // 100k Honeywell 135-104LAG-J01
+#define NUMTEMPS_7 54
+const short temptable_7[NUMTEMPS_7][2] = {
+   {46, 270},
+   {50, 265},
+   {54, 260},
+   {58, 255},
+   {62, 250},
+   {67, 245},
+   {72, 240},
+   {79, 235},
+   {85, 230},
+   {91, 225},
+   {99, 220},
+   {107, 215},
+   {116, 210},
+   {126, 205},
+   {136, 200},
+   {149, 195},
+   {160, 190},
+   {175, 185},
+   {191, 180},
+   {209, 175},
+   {224, 170},
+   {246, 165},
+   {267, 160},
+   {293, 155},
+   {316, 150},
+   {340, 145},
+   {364, 140},
+   {396, 135},
+   {425, 130},
+   {460, 125},
+   {489, 120},
+   {526, 115},
+   {558, 110},
+   {591, 105},
+   {628, 100},
+   {660, 95},
+   {696, 90},
+   {733, 85},
+   {761, 80},
+   {794, 75},
+   {819, 70},
+   {847, 65},
+   {870, 60},
+   {892, 55},
+   {911, 50},
+   {929, 45},
+   {944, 40},
+   {959, 35},
+   {971, 30},
+   {981, 25},
+   {989, 20},
+   {994, 15},
+   {1001, 10},
+   {1005, 5}
+};
+#endif
+
+
 #if THERMISTORHEATER == 1
 #define NUMTEMPS NUMTEMPS_1
 #define temptable temptable_1
@@ -240,6 +343,12 @@ const short temptable_5[NUMTEMPS_5][2] = {
 #elif THERMISTORHEATER == 5
 #define NUMTEMPS NUMTEMPS_5
 #define temptable temptable_5
+#elif THERMISTORHEATER == 6
+#define NUMTEMPS NUMTEMPS_6
+#define temptable temptable_6
+#elif THERMISTORHEATER == 7
+#define NUMTEMPS NUMTEMPS_7
+#define temptable temptable_7
 #elif defined HEATER_USES_THERMISTOR
 #error No heater thermistor table specified
 #endif
@@ -258,6 +367,12 @@ const short temptable_5[NUMTEMPS_5][2] = {
 #elif THERMISTORBED == 5
 #define BNUMTEMPS NUMTEMPS_5
 #define bedtemptable temptable_5
+#elif THERMISTORBED == 6
+#define BNUMTEMPS NUMTEMPS_6
+#define bedtemptable temptable_6
+#elif THERMISTORBED == 7
+#define BNUMTEMPS NUMTEMPS_7
+#define bedtemptable temptable_7
 #elif defined BED_USES_THERMISTOR
 #error No bed thermistor table specified
 #endif


### PR DESCRIPTION
I've added a 6th and 7th thermistor table that can also be currently found in the Sprinter firmware.
